### PR TITLE
(CDPE-2288) Add more hiera hierarchies for testing hiera IA files

### DIFF
--- a/data2/common.yaml
+++ b/data2/common.yaml
@@ -1,0 +1,2 @@
+---
+profile::base::hiera_lookup_test2: "staging2"

--- a/data3/common.yaml
+++ b/data3/common.yaml
@@ -1,0 +1,2 @@
+---
+profile::base::hiera_lookup_test3: "staging3"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,3 +10,15 @@ hierarchy:
     paths:
       - "nodes/%{trusted.certname}.yaml"
       - "common.yaml"
+  - name: "Yaml backend 2"
+    data_hash: yaml_data
+    datadir: "data2"
+    paths:
+      - "nodes/%{trusted.certname}.yaml"
+      - "common.yaml"
+  - name: "Yaml backend 3"
+    data_hash: yaml_data
+    datadir: "data3"
+    paths:
+      - "nodes/%{trusted.certname}.yaml"
+      - "common.yaml"

--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -7,6 +7,11 @@ class profile::base {
     message => $var,
   }
 
+  $var2 = lookup('profile::base::hiera_lookup_test2')
+  notify { "2nd value from hiera":
+    message => $var2,
+  }
+
   file { "/tmp/sensitive":
     ensure => file,
     content => Sensitive("totaly not sensitive")
@@ -17,12 +22,12 @@ class profile::base {
   }
 
   if $facts['id'] =~ /^user/ {
-    class { 'clamps': 
+    class { 'clamps':
       num_dynamic_files => 1,
       num_static_files  => 1,
     }
   } else {
-    class { 'clamps::agent': 
+    class { 'clamps::agent':
       nonroot_users => 5,
       daemonize => true,
     }


### PR DESCRIPTION
- Adds several new hierarchies so we can test that Hiera IA correctly
builds a set of datadirs to use in locating changed Hiera files.
- For each new backend it adds a single hiera key that is meant to be
changed between impact_analysis_tests_staging and _prod.