### PR TITLE
(CDPE-2288) Add hiera changes for IA testing

### DIFF
--- a/data2/common.yaml
+++ b/data2/common.yaml
@@ -1,0 +1,2 @@
+---
+profile::base::hiera_lookup_test2: "production2"

--- a/data4/common.yaml
+++ b/data4/common.yaml
@@ -1,0 +1,2 @@
+---
+profile::base::hiera_lookup_test4: "production4"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,3 +10,21 @@ hierarchy:
     paths:
       - "nodes/%{trusted.certname}.yaml"
       - "common.yaml"
+  - name: "Yaml backend 2"
+    data_hash: yaml_data
+    datadir: "data2"
+    paths:
+      - "nodes/%{trusted.certname}.yaml"
+      - "common.yaml"
+  - name: "Yaml backend 3"
+    data_hash: yaml_data
+    datadir: "data3"
+    paths:
+      - "nodes/%{trusted.certname}.yaml"
+      - "common.yaml"
+  - name: "Yaml backend 4"
+    data_hash: yaml_data
+    datadir: "data4"
+    paths:
+      - "nodes/%{trusted.certname}.yaml"
+      - "common.yaml"


### PR DESCRIPTION
- Adds several new hierarchies so we can test that Hiera IA correctly
builds a set of datadirs to use in locating changed Hiera files.
- For each new backend it adds a single hiera key that is meant to be
changed between impact_analysis_tests_staging and _prod