### PR TITLE
(maint) Update Puppetfile with cd4pe https url

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,5 @@
 mod 'cd4pe',
-  :git => 'git@github.com:puppetlabs/puppetlabs-cd4pe.git',
+  :git => 'https://github.com/puppetlabs/puppetlabs-cd4pe.git',
   :ref => 'master'
 mod 'clamps',
   :git => 'https://github.com/puppetlabs/clamps.git',


### PR DESCRIPTION
- In a containerized PE test environment without SSH keys setup, cloning over SSH won't work

  Change the cd4pe module to use a https URI so that this isn't an issue